### PR TITLE
Add collapsible details for PDF entries

### DIFF
--- a/src/PdfTextExtractor.css
+++ b/src/PdfTextExtractor.css
@@ -1,0 +1,21 @@
+.pdf-entries {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.pdf-entry {
+  margin-bottom: 0.5rem;
+}
+
+.pdf-entry details {
+  background: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 0.5rem;
+}
+
+.pdf-entry summary {
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/src/PdfTextExtractor.tsx
+++ b/src/PdfTextExtractor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
+import './PdfTextExtractor.css';
 GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs';
 
 interface PdfTextExtractorProps {
@@ -97,8 +98,13 @@ const PdfTextExtractor: React.FC<PdfTextExtractorProps> = ({ pdfUrl }) => {
   return (
     <ul className="pdf-entries">
       {entries.map((e) => (
-        <li key={e.id}>
-          <strong>{e.id}</strong> - {e.text}
+        <li key={e.id} className="pdf-entry">
+          <details>
+            <summary>
+              <strong>{e.id}</strong>
+            </summary>
+            <p>{e.text}</p>
+          </details>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- make PDF entries collapsible in `PdfTextExtractor`
- add styles for collapsible entries

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e9a14f6488329a6dd6dc3f2ce3cb3