### PR TITLE
Enhance item display using details

### DIFF
--- a/src/SumarioViewer.css
+++ b/src/SumarioViewer.css
@@ -115,3 +115,10 @@
   .item a:hover {
     text-decoration: underline;
   }
+
+  .item details {
+    cursor: pointer;
+  }
+
+  .item summary {
+    margin-bottom: 0.5rem;  }

--- a/src/SumarioViewer.tsx
+++ b/src/SumarioViewer.tsx
@@ -39,14 +39,17 @@ const SumarioViewer: React.FC<SumarioViewerProps> = ({ sumario }) => {
           <ul className="items">
             {filteredItems.map((item: any, iIdx: number) => (
               <li key={iIdx} className="item">
-                <p><strong>Identificador:</strong> {item.identificador}</p>
-                <p><strong>Título:</strong> {item.titulo}</p>
-                {item.url_pdf && (
-                  <div>
-                    <strong>Texto PDF:</strong>
-                    <PdfTextExtractor pdfUrl={item.url_pdf.texto} />
+                <details>
+                  <summary>
+                    <strong>Identificador:</strong> {item.identificador} –{' '}
+                    <strong>Título:</strong> {item.titulo}
+                  </summary>
+                  {item.url_pdf && (
+                    <div className="pdf-text">
+                      <PdfTextExtractor pdfUrl={item.url_pdf.texto} />
                     </div>
-                )}
+                  )}
+                </details>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- collapse each company item in a `<details>` section
- style the new details element for usability

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e9a14f6488329a6dd6dc3f2ce3cb3