### PR TITLE
Show PDF entries in collapsible details

### DIFF
--- a/src/PdfTextExtractor.tsx
+++ b/src/PdfTextExtractor.tsx
@@ -97,8 +97,14 @@ const PdfTextExtractor: React.FC<PdfTextExtractorProps> = ({ pdfUrl }) => {
   return (
     <ul className="pdf-entries">
       {entries.map((e) => (
-        <li key={e.id}>
-          <strong>{e.id}</strong> - {e.text}
+        <li key={e.id} className="pdf-entry">
+          <details>
+            <summary>
+              <strong>{e.id}</strong> - {e.text.slice(0, 50)}
+              {e.text.length > 50 ? '…' : ''}
+            </summary>
+            <p>{e.text}</p>
+          </details>
         </li>
       ))}
     </ul>

--- a/src/SumarioViewer.css
+++ b/src/SumarioViewer.css
@@ -113,5 +113,17 @@
   }
   
   .item a:hover {
-    text-decoration: underline;
+    text-decoration: underline;  }
+
+  .pdf-entries {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .pdf-entry details {
+    margin: 0.4rem 0;
+  }
+
+  .pdf-entry summary {
+    cursor: pointer;
   }


### PR DESCRIPTION
## Summary
- render extracted PDF objects as `<details>` in `PdfTextExtractor`
- add basic CSS for `.pdf-entry` lists

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e9a14f6488329a6dd6dc3f2ce3cb3