### PR TITLE
Add collapsible details for PDF entries

### DIFF
--- a/src/PdfTextExtractor.tsx
+++ b/src/PdfTextExtractor.tsx
@@ -98,7 +98,13 @@ const PdfTextExtractor: React.FC<PdfTextExtractorProps> = ({ pdfUrl }) => {
     <ul className="pdf-entries">
       {entries.map((e) => (
         <li key={e.id}>
-          <strong>{e.id}</strong> - {e.text}
+          <details>
+            <summary>
+              <strong>{e.id}</strong>
+              {e.text.length > 80 ? ` - ${e.text.slice(0, 80)}...` : ` - ${e.text}`}
+            </summary>
+            <p>{e.text}</p>
+          </details>
         </li>
       ))}
     </ul>

--- a/src/SumarioViewer.css
+++ b/src/SumarioViewer.css
@@ -115,3 +115,10 @@
   .item a:hover {
     text-decoration: underline;
   }
+
+  .pdf-entries details {
+    margin-bottom: 0.5rem;
+  }
+
+  .pdf-entries summary {
+    cursor: pointer;  }


### PR DESCRIPTION
## Summary
- wrap each parsed PDF line in `<details>` so content can be collapsed
- add simple CSS for the new details lists

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e9a14f6488329a6dd6dc3f2ce3cb3