### PR TITLE
Fix regex to parse fields with periods in PDF text

### DIFF
--- a/src/PdfTextExtractor.tsx
+++ b/src/PdfTextExtractor.tsx
@@ -32,7 +32,7 @@ const parseConstitutionText = (text: string): CompanyData | null => {
   if (nombreMatch) {
     data.nombre = nombreMatch[1].trim();
   }
-  const comienzoMatch = text.match(/Comienzo de operaciones:\s*([^\.]+)\./i);
+  const comienzoMatch = text.match(/Comienzo de operaciones:\s*(.+?)(?=\.\s+[A-ZÁÉÍÓÚÑ]|$)/i);
   if (comienzoMatch) {
     data.comienzo = comienzoMatch[1].trim();
   }
@@ -44,11 +44,11 @@ const parseConstitutionText = (text: string): CompanyData | null => {
   if (domicilioMatch) {
     data.domicilio = domicilioMatch[1].trim();
   }
-  const capitalMatch = text.match(/Capital:\s*([^\.]+)\./i);
+  const capitalMatch = text.match(/Capital:\s*(.+?)(?=\.\s+[A-ZÁÉÍÓÚÑ]|$)/i);
   if (capitalMatch) {
     data.capital = capitalMatch[1].trim();
   }
-  const nomMatch = text.match(/Nombramientos\.\s*([^\.]+)\./i);
+  const nomMatch = text.match(/Nombramientos\.\s*(.+?)(?=\.\s+[A-ZÁÉÍÓÚÑ]|$)/i);
   if (nomMatch) {
     data.nombramientos = nomMatch[1].trim();
   }


### PR DESCRIPTION
## Summary
- improve regex patterns to capture dates, decimals, and multi-sentence fields

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ec8614b4c8329a5f5422482ce90f7