### PR TITLE
Fix full nomination extraction

### DIFF
--- a/src/PdfTextExtractor.tsx
+++ b/src/PdfTextExtractor.tsx
@@ -40,7 +40,7 @@ const parseConstitutionText = (text: string): CompanyData | null => {
   if (objetoMatch) {
     data.objeto = objetoMatch[1].trim();
   }
-  const domicilioMatch = text.match(/Domicilio:\s*([^\.]+)\./i);
+  const domicilioMatch = text.match(/Domicilio:\s*([^.]+)\./i);
   if (domicilioMatch) {
     data.domicilio = domicilioMatch[1].trim();
   }
@@ -48,7 +48,7 @@ const parseConstitutionText = (text: string): CompanyData | null => {
   if (capitalMatch) {
     data.capital = capitalMatch[1].trim();
   }
-  const nomMatch = text.match(/Nombramientos\.\s*(.+?)(?=\.\s+[A-ZÁÉÍÓÚÑ]|$)/i);
+  const nomMatch = text.match(/Nombramientos[.]\s*(.+?)(?=\.\s*Datos registrales|$)/i);
   if (nomMatch) {
     data.nombramientos = nomMatch[1].trim();
   }


### PR DESCRIPTION
## Summary
- adjust regex to capture entire nomination text
- clean up lint error in domicile regex

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ed4d7a5b4832983e61076cdfb148b